### PR TITLE
vs2013: fix leak, vs2015+: use unrestricted union

### DIFF
--- a/include/autocheck/value.hpp
+++ b/include/autocheck/value.hpp
@@ -15,17 +15,22 @@ namespace autocheck {
         None,
         Static,
         Heap
-      }    allocation = None;
+      }    allocation =
 
-#ifndef _MSC_VER
-      //Visual Studio 2013 doesn't support unrestricted unions
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+                        None;
+
       union {
+#else
+                        Static;
+	  //Visual Studio 2013 doesn't support unrestricted unions
 #endif
         T* pointer = nullptr;
         T  object;
-#ifndef _MSC_VER
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
       };
 #endif
+
 
     public:
       value() {}


### PR DESCRIPTION
As unrestricted unions are not used for Visual Studio 2013, default
```
T  object;
```
field is created in `value` template class default contructor. But as `allocation` is initialized with `None` this default object leaks, when we start to generate test values. So, for example, there is a memory leak in the following code, if it is compiled by Visual Studio 2013:
```
autocheck::check<std::string>([](const std::string& str) { return true; });
```

Patch fixes this leakage and turns on unrestricted union usage for Visual Studio 2015+.